### PR TITLE
Add duplicate artifact functionality

### DIFF
--- a/src/components/ComputingGalleryManager.jsx
+++ b/src/components/ComputingGalleryManager.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Camera, Edit2, Trash2, Plus, Search, Filter, Save, X, CheckCircle, Clock, DollarSign, Grid, List, LogIn, LogOut, User, Shield, Package, Eye } from 'lucide-react';
+import { Camera, Edit2, Trash2, Plus, Search, Filter, Save, X, CheckCircle, Clock, DollarSign, Grid, List, LogIn, LogOut, User, Shield, Package, Eye, Copy } from 'lucide-react';
 import ExhibitManager from './ExhibitManager';
 
 // Firebase imports
@@ -421,6 +421,31 @@ const ComputingGalleryManager = () => {
     setShowForm(true);
   };
 
+  const handleDuplicate = (artifact) => {
+    // Copy all fields except ID and add " (Copy)" to the name
+    setFormData({
+      name: `${artifact.name} (Copy)`,
+      category: artifact.category || '',
+      manufacturer: artifact.manufacturer || '',
+      model: artifact.model || '',
+      year: artifact.year || '',
+      os: artifact.os || '',
+      description: artifact.description || '',
+      condition: artifact.condition || '',
+      displayGroup: artifact.displayGroup || '',
+      location: artifact.location || '',
+      value: artifact.value || '',
+      acquisitionDate: artifact.acquisitionDate || '',
+      donor: artifact.donor || '',
+      status: artifact.status || 'To Do',
+      priority: artifact.priority || 'Medium',
+      notes: artifact.notes || '',
+      images: artifact.images || []
+    });
+    setEditingId(null); // This is a new artifact, not an edit
+    setShowForm(true);
+  };
+
   const handleDelete = async (id) => {
     if (window.confirm('Are you sure you want to delete this artifact?')) {
       try {
@@ -670,16 +695,26 @@ const ComputingGalleryManager = () => {
                           <button
                             onClick={() => handleEdit(artifact)}
                             className="flex-1 px-3 py-1 bg-blue-50 text-blue-600 rounded hover:bg-blue-100 transition-colors flex items-center justify-center gap-1"
+                            title="Edit artifact"
                           >
                             <Edit2 className="w-4 h-4" />
-                            Edit
+                            <span className="hidden sm:inline">Edit</span>
+                          </button>
+                          <button
+                            onClick={() => handleDuplicate(artifact)}
+                            className="flex-1 px-3 py-1 bg-purple-50 text-purple-600 rounded hover:bg-purple-100 transition-colors flex items-center justify-center gap-1"
+                            title="Duplicate artifact"
+                          >
+                            <Copy className="w-4 h-4" />
+                            <span className="hidden sm:inline">Duplicate</span>
                           </button>
                           <button
                             onClick={() => handleDelete(artifact.id)}
                             className="flex-1 px-3 py-1 bg-red-50 text-red-600 rounded hover:bg-red-100 transition-colors flex items-center justify-center gap-1"
+                            title="Delete artifact"
                           >
                             <Trash2 className="w-4 h-4" />
-                            Delete
+                            <span className="hidden sm:inline">Delete</span>
                           </button>
                         </div>
                       )}
@@ -733,6 +768,13 @@ const ComputingGalleryManager = () => {
                                 title="Edit"
                               >
                                 <Edit2 className="w-4 h-4" />
+                              </button>
+                              <button
+                                onClick={() => handleDuplicate(artifact)}
+                                className="text-purple-600 hover:text-purple-800"
+                                title="Duplicate"
+                              >
+                                <Copy className="w-4 h-4" />
                               </button>
                               <button
                                 onClick={() => handleDelete(artifact.id)}


### PR DESCRIPTION
## Description

This PR adds the ability to duplicate artifacts in the Computing Artifacts Gallery Manager. This feature makes it easy to create similar artifacts by copying all the data from an existing artifact.

## Changes Made

1. **Added the Copy icon** from lucide-react to the imports
2. **Created a new `handleDuplicate` function** that:
   - Copies all fields from the selected artifact
   - Appends " (Copy)" to the artifact name
   - Opens the form in "create new" mode (not edit mode)
   - Preserves all data including images

3. **Added Duplicate button** in both views:
   - **Grid view**: Purple "Duplicate" button between Edit and Delete buttons
   - **List view**: Purple duplicate icon in the actions column

## Visual Changes

- The duplicate button uses a purple color scheme (purple-50 background, purple-600 text) to distinguish it from the blue Edit and red Delete buttons
- On smaller screens, the button text is hidden and only the icon is shown
- Hover states change the button to purple-100 background

## How to Test

1. Log in as an admin user
2. Navigate to the Artifacts tab
3. Find any artifact you want to duplicate
4. Click the "Duplicate" button (or copy icon in list view)
5. The form should open with all the artifact data pre-filled
6. The artifact name should have " (Copy)" appended
7. Save the duplicated artifact

## Benefits

- Speeds up data entry when adding similar artifacts
- Reduces errors by starting with known-good data
- Preserves all artifact details including images, condition, and notes