### PR TITLE
Fix artifact card click area - remove stopPropagation from content div

### DIFF
--- a/src/components/ComputingGalleryManager.jsx
+++ b/src/components/ComputingGalleryManager.jsx
@@ -686,7 +686,7 @@ const ComputingGalleryManager = () => {
                       )}
                     </div>
                     
-                    <div className="p-4" onClick={(e) => e.stopPropagation()}>
+                    <div className="p-4">
                       <div className="flex items-start justify-between mb-2">
                         <h3 className="text-lg font-semibold text-gray-900">{artifact.name}</h3>
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
This change allows users to click anywhere on the artifact card to open the detail modal. The admin buttons still have their own stopPropagation to prevent the modal from opening when they are clicked.