### PR TITLE
Fix exhibit styling: Add success modal and portrait images

### DIFF
--- a/src/components/ExhibitManager.jsx
+++ b/src/components/ExhibitManager.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { 
   Plus, Edit2, Trash2, X, Save, Upload, Image as ImageIcon, 
-  Grid, List, Eye, Calendar, MapPin, Users
+  Grid, List, Eye, Calendar, MapPin, Users, CheckCircle
 } from 'lucide-react';
 import { db, storage } from '../firebase';
 import { 
@@ -19,6 +19,7 @@ const ExhibitManager = ({ user, isAdmin, artifacts }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [uploading, setUploading] = useState(false);
   const [viewMode, setViewMode] = useState('grid');
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
   
   const [formData, setFormData] = useState({
     name: '',
@@ -102,7 +103,12 @@ const ExhibitManager = ({ user, isAdmin, artifacts }) => {
       
       await loadExhibits();
       resetForm();
-      alert('Exhibit saved successfully!');
+      setShowSuccessModal(true);
+      
+      // Auto-hide success modal after 3 seconds
+      setTimeout(() => {
+        setShowSuccessModal(false);
+      }, 3000);
     } catch (error) {
       console.error('Error saving exhibit:', error);
       alert('Error saving exhibit. Please try again.');
@@ -638,6 +644,40 @@ const ExhibitManager = ({ user, isAdmin, artifacts }) => {
           </div>
         </div>
       )}
+
+      {/* Success Modal */}
+      {showSuccessModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg shadow-xl max-w-sm w-full animate-fade-in-up">
+            <div className="p-6 text-center">
+              <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                Success!
+              </h3>
+              <p className="text-gray-600">
+                Your exhibit has been {editingId ? 'updated' : 'created'} successfully.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style jsx>{`
+        @keyframes fade-in-up {
+          0% {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          100% {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        
+        .animate-fade-in-up {
+          animation: fade-in-up 0.3s ease-out;
+        }
+      `}</style>
     </div>
   );
 };

--- a/src/components/ExhibitView.jsx
+++ b/src/components/ExhibitView.jsx
@@ -284,12 +284,12 @@ const ExhibitView = () => {
                   className="bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer"
                   onClick={() => setSelectedArtifact(artifact)}
                 >
-                  <div className="aspect-video bg-gray-100 relative overflow-hidden">
+                  <div className="aspect-[3/4] bg-gray-100 relative overflow-hidden">
                     {artifact.images && artifact.images[0] ? (
                       <img 
                         src={artifact.images[0]} 
                         alt={artifact.name} 
-                        className="w-full h-full object-cover"
+                        className="w-full h-full object-contain"
                       />
                     ) : (
                       <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
This PR addresses two styling improvements for the exhibit functionality:

## Changes Made:

### 1. Styled Success Modal in ExhibitManager
- Replaced the browser's native `alert()` with a custom styled modal when saving exhibits
- Added a green checkmark icon and success message
- Modal automatically dismisses after 3 seconds
- Includes smooth fade-in animation
- Matches the overall design aesthetic of the application

### 2. Portrait Aspect Ratio for Artifact Images in ExhibitView
- Changed artifact image containers from `aspect-video` to `aspect-[3/4]` (portrait)
- Updated image display to use `object-contain` to preserve aspect ratio
- This makes the exhibit page images consistent with the gallery page display
- Images now properly show portrait-oriented artifacts without cropping

## Visual Impact:
- The success modal provides better user feedback with a more polished look
- Portrait images on the exhibit page now match the gallery display for consistency
- Both changes improve the overall user experience and visual coherence